### PR TITLE
Adds option to use credentials file to pass in credentials

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -100,7 +100,7 @@ dns_porkbun_key=<your-porkbun-api-key>
 dns_porkbun_secret=<your-porkbun-api-secret>
 ```
 
-And then instead of using the `--dns-porkbun-key` parameter above you can use
+And then instead of using the `--dns-porkbun-key` and `--dns-porkbun-secret` parameters above you can use
 
 ```commandline
 ...

--- a/Readme.md
+++ b/Readme.md
@@ -12,9 +12,9 @@ Plugin for certbot to obtain certificates using a DNS TXT record for Porkbun dom
 
 1. [About](#about)
 2. [Installation](#installation)
-    1. [Prerequirements](#prerequirements)
-    2. [With pip (recommend)](#with-pip-recommend)
-    3. [From source](#from-source)
+   1. [Prerequirements](#prerequirements)
+   2. [With pip (recommend)](#with-pip-recommend)
+   3. [From source](#from-source)
 3. [Usage](#usage)
 4. [FAQ](#faq)
 5. [Third party notices](#third-party-notices)
@@ -24,7 +24,7 @@ Plugin for certbot to obtain certificates using a DNS TXT record for Porkbun dom
 
 ### About
 
-*certbot_dns_porkbun* is a plugin for [*certbot*](https://github.com/certbot/certbot). It handles the TXT record for the
+_certbot_dns_porkbun_ is a plugin for [_certbot_](https://github.com/certbot/certbot). It handles the TXT record for the
 DNS-01 challenge for Porkbun domains. The plugin takes care of the creation and deletion of the TXT record using the
 Porkbun API.
 
@@ -35,9 +35,9 @@ Porkbun API.
 You need at least version `3.6` of Python installed. If you want to install the plugin with pip, then you must also have
 pip installed beforehand.
 
-If you already have *certbot* installed, make sure you have at least version `1.1.0` installed.
+If you already have _certbot_ installed, make sure you have at least version `1.1.0` installed.
 
-You can check what version of *certbot* is installed with this command:
+You can check what version of _certbot_ is installed with this command:
 
 ```commandline
 certbot --version
@@ -51,7 +51,7 @@ certbot cannot find the plugin.**
 
 #### With pip (recommend)
 
-Use the following command to install *certbot_dns_porkbun* with pip:
+Use the following command to install _certbot_dns_porkbun_ with pip:
 
 ```commandline
 pip3 install certbot_dns_porkbun
@@ -82,6 +82,32 @@ certbot plugins
 ```
 
 The resulting list should include `dns-porkbun` if everything went fine.
+
+#### Credentials file or cli parameters
+
+You can either use cli parameters to pass authentication information to certbot:
+
+```commandline
+...
+--dns-porkbun-key <your-porkbun-api-key> \
+--dns-porkbun-secret <your-porkbun-api-secret>
+```
+
+Or to prevent your credentials from showing up in your bash history, you can also create a credentials-file `porkbun.ini` (the name does not matter) with the following content:
+
+```ini
+dns_porkbun_key=<your-porkbun-api-key>
+dns_porkbun_secret=<your-porkbun-api-secret>
+```
+
+And then instead of using the `--dns-porkbun-key` parameter above you can use
+
+```commandline
+...
+--dns-porkbun-credentials </path/to/your/porkbun.ini>
+```
+
+You can also mix these usages, though the cli parameters always take precedence over the ini file.
 
 #### Examples
 
@@ -118,6 +144,20 @@ certbot certonly \
   -d "*.example.com"
 ```
 
+Generate a certificate with a DNS-01 challenge for the domain `example.org` using a credentials ini file:
+
+```commandline
+certbot certonly \
+  --non-interactive \
+  --agree-tos \
+  --email <your-email-address> \
+  --preferred-challenges dns \
+  --authenticator dns-porkbun \
+  --dns-porkbun-credentials </path/to/your/porkbun.ini> \
+  --dns-porkbun-propagation-seconds 60 \
+  -d "example.com"
+```
+
 Generate a certificate with a DNS-01 challenge for the domain `example.com` without an account (i.e. without an email
 address):
 
@@ -152,19 +192,19 @@ certbot certonly \
 ```
 
 You can find al list of all available certbot cli options in
-the [official documentation](https://certbot.eff.org/docs/using.html#certbot-command-line-options) of *certbot*.
+the [official documentation](https://certbot.eff.org/docs/using.html#certbot-command-line-options) of _certbot_.
 
 ### Third party notices
 
 All modules used by this project are listed below:
 
-| Name | License|
-|:---:|:---:|
-| [certbot](https://github.com/certbot/certbot) | [Apache 2.0](https://raw.githubusercontent.com/certbot/certbot/master/LICENSE.txt) |
-| [requests](https://github.com/psf/requests) | [Apache 2.0](https://raw.githubusercontent.com/psf/requests/master/LICENSE) |
+|                                Name                                |                                            License                                            |
+| :----------------------------------------------------------------: | :-------------------------------------------------------------------------------------------: |
+|           [certbot](https://github.com/certbot/certbot)            |      [Apache 2.0](https://raw.githubusercontent.com/certbot/certbot/master/LICENSE.txt)       |
+|            [requests](https://github.com/psf/requests)             |          [Apache 2.0](https://raw.githubusercontent.com/psf/requests/master/LICENSE)          |
 | [zope.interface](https://github.com/zopefoundation/zope.interface) | [ZPL-2.1](https://raw.githubusercontent.com/zopefoundation/zope.interface/master/LICENSE.txt) |
-| [setuptools](https://github.com/pypa/setuptools) | [MIT](https://raw.githubusercontent.com/pypa/setuptools/main/LICENSE) |
-| [pkb_client](https://github.com/infinityofspace/pkb_client) | [MIT](https://github.com/infinityofspace/pkb_client/blob/main/License) |
+|          [setuptools](https://github.com/pypa/setuptools)          |             [MIT](https://raw.githubusercontent.com/pypa/setuptools/main/LICENSE)             |
+|    [pkb_client](https://github.com/infinityofspace/pkb_client)     |            [MIT](https://github.com/infinityofspace/pkb_client/blob/main/License)             |
 
 Furthermore, this readme file contains embeddings of [Shields.io](https://github.com/badges/shields)
 and [PePy](https://github.com/psincraian/pepy).


### PR DESCRIPTION
This allows passing in a credentials file for authentication without breaking cli parameter usage.

Unfortunately I do not have a porkbun account, so I was just able to test up to the actual challange execution, where the authentication fails. But it does work up to that point.

Fixes #1 .