### PR TITLE
Add README note to avoid issues with parked domains

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -114,7 +114,7 @@ certbot plugins
 
 ### Usage
 
-**Note: By default, Porkbun domains cannot be controlled through the API. This will cause an error when you generate certificates. Ensure that you have enabled API Access in your domain's settings to avoid this. If you haven't already, be sure to also delete the (default) parked domain ALIAS records, as not doing so will cause errors.**
+**Note: By default, Porkbun domains cannot be controlled through the API. This will cause an error when you generate certificates. Ensure that you have enabled API Access in your domain's settings to avoid this. If you haven't already, be sure to also delete the (default) parked domain ALIAS records, as not doing so may cause errors.**
 
 #### Local installation
 

--- a/Readme.md
+++ b/Readme.md
@@ -114,6 +114,8 @@ certbot plugins
 
 ### Usage
 
+**Note: By default, Porkbun domains cannot be controlled through the API. This will cause an error when you generate certificates. Ensure that you have enabled API Access in your domain's settings to avoid this. If you haven't already, be sure to also delete the (default) parked domain ALIAS records, as not doing so will cause errors.**
+
 #### Local installation
 
 To check if the plugin is installed and detected properly by certbot, you can use the following command:


### PR DESCRIPTION
Unconfigured (parked) Porkbun domains have trouble using dns-porkbun. By default, Porkbun does not enable API access on domains, and two default ALIAS records pointing to Porkbun's domains make dns-porkbun do a CNAME forwarded verification with Porkbun's domain. The latter issue is particularly bad because the only error given is an `Invalid domain.` error, which more-or-less leaves you to intuit that your domain redirected verification to another. I would consider adding a log message to more clearly indicate the result of domain resolutions, though I digress.

These issues should only appear on parked Porkbun domains. The software is behaving exactly as it should, but some people (myself included) may try to generate certificates before setting up their DNS records, potentially causing them issues. To remedy this, I'm opening this PR with a note advising users to enable API access and remove the default ALIAS records.

Thanks!