### PR TITLE
added attestation of docker image builds closes #86

### DIFF
--- a/.github/workflows/docker-publish-dev.yml
+++ b/.github/workflows/docker-publish-dev.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+
     steps:
       - name: checkout code
         uses: actions/checkout@v4
@@ -42,3 +46,10 @@ jobs:
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Attest
+        uses: actions/attest-build-provenance@v1
+        id: attest
+        with:
+          subject-name: ghcr.io/${{ secrets.GH_USERNAME }}/certbot_dns_porkbun
+          subject-digest: ${{ steps.build-push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-publish-release.yml
+++ b/.github/workflows/docker-publish-release.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+
     steps:
       - name: get the tag name
         id: get_tag
@@ -48,3 +52,10 @@ jobs:
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Attest
+        uses: actions/attest-build-provenance@v1
+        id: attest
+        with:
+          subject-name: ghcr.io/${{ secrets.GH_USERNAME }}/certbot_dns_porkbun
+          subject-digest: ${{ steps.build-push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-publish-unstable.yml
+++ b/.github/workflows/docker-publish-unstable.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+
     steps:
       - name: checkout code
         uses: actions/checkout@v4
@@ -42,3 +46,10 @@ jobs:
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Attest
+        uses: actions/attest-build-provenance@v1
+        id: attest
+        with:
+          subject-name: ghcr.io/${{ secrets.GH_USERNAME }}/certbot_dns_porkbun
+          subject-digest: ${{ steps.build-push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Adds support for docker image build attestation, so we can verify that the docker image in the registry was build with the corresponding GitHub workflow and within GitHub Action.