### PR TITLE
Add logging messages when resolving domain name

### DIFF
--- a/certbot_dns_porkbun/cert/client.py
+++ b/certbot_dns_porkbun/cert/client.py
@@ -105,6 +105,7 @@ class Authenticator(dns_common.DNSAuthenticator):
         try:
             # follow all CNAME and DNAME records
             canonical_name = resolver.canonical_name(domain)
+            logging.info("Resolved domain '%s' to '%s' via CNAME/DNAME record", domain, canonical_name)
         except (resolver.NoAnswer, resolver.NXDOMAIN):
             canonical_name = domain
 
@@ -112,6 +113,7 @@ class Authenticator(dns_common.DNSAuthenticator):
         root_domain = f"{extract_result.domain}.{extract_result.suffix}"
         name = extract_result.subdomain
 
+        logging.info("Creating DNS challenge response record for %s", root_domain)
         try:
             self._validation_to_record[validation] = (
                 client.create_dns_record(


### PR DESCRIPTION
This can help people, like me, who don't realize that CNAME records will cause the plugin to attempt the DNS challenge on another top-level domain if their records are configured to do that.

Resolves issue #100 