### PR TITLE
Fix existing records handling

### DIFF
--- a/certbot_dns_porkbun/cert/client.py
+++ b/certbot_dns_porkbun/cert/client.py
@@ -163,7 +163,9 @@ class Authenticator(dns_common.DNSAuthenticator):
 
         if record_id is None:
             logging.warning(
-                f"No challenge TXT record found for domain {root_domain} with value {validation}"
+                "No challenge TXT record found for domain %s with value %s",
+                domain,
+                validation,
             )
         elif not self._get_porkbun_client().delete_dns_record(root_domain, record_id):
             raise errors.PluginError(f"TXT for domain {root_domain} was not deleted")


### PR DESCRIPTION
The clean-up process logic requires all records to be created during the same plugin execution. Moreover, retrying a dns challenge when an existing record with the same value exists, results in a crash.
To fix this issue, we check for existing records with api and do not use a local record is storage.