### PR TITLE
Check if DNS challenge already exists

### DIFF
--- a/tests/cert_client.py
+++ b/tests/cert_client.py
@@ -168,6 +168,129 @@ class TestCertClient(unittest.TestCase):
         )
 
     @responses.activate
+    def test_perform_existing_record_different(self):
+        responses.post(
+            url="https://api.porkbun.com/api/json/v3/dns/retrieveByNameType/example.com/TXT/_acme-challenge",
+            json={
+                "status": "SUCCESS",
+                "records": [
+                    {
+                        "id": "123456788",
+                        "name": "_acme-challenge",
+                        "type": "TXT",
+                        "content": "ABCDEFG",
+                        "ttl": "600",
+                        "prio": "0",
+                        "notes": ""
+                    }
+                ]
+            },
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "apikey": "key",
+                        "secretapikey": "secret"
+                    }
+                )
+            ]
+        )
+        responses.post(
+            url="https://api.porkbun.com/api/json/v3/dns/create/example.com",
+            json={"status": "SUCCESS", "id": "123456789"},
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "apikey": "key",
+                        "content": "ABCDEF",
+                        "name": "_acme-challenge",
+                        "prio": None,
+                        "secretapikey": "secret",
+                        "ttl": 300,
+                        "type": "TXT",
+                    }
+                )
+            ],
+        )
+        responses.add_passthru("https://publicsuffix.org/list/public_suffix_list.dat")
+        responses.add_passthru(
+            "https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat"
+        )
+
+        namespace = Namespace(
+            porkbun_key="key",
+            porkbun_secret="secret",
+            porkbun_propagation_seconds=600,
+            config_dir="config_dir",
+            work_dir="work_dir",
+            logs_dir="logs_dir",
+            http01_port=80,
+            https_port=443,
+            domains=["example.com"],
+        )
+        config = NamespaceConfig(namespace)
+
+        authenticator = Authenticator(config, name="porkbun")
+
+        authenticator._perform(
+            domain="example.com", validation_name="", validation="ABCDEF"
+        )
+        assert responses.assert_call_count("https://api.porkbun.com/api/json/v3/dns/retrieveByNameType/example.com/TXT/_acme-challenge", 1) is True
+        assert responses.assert_call_count("https://api.porkbun.com/api/json/v3/dns/create/example.com", 1) is True
+
+    @responses.activate
+    def test_perform_existing_record_same(self):
+        responses.post(
+            url="https://api.porkbun.com/api/json/v3/dns/retrieveByNameType/example.com/TXT/_acme-challenge",
+            json={
+                "status": "SUCCESS",
+                "records": [
+                    {
+                        "id": "123456788",
+                        "name": "_acme-challenge",
+                        "type": "TXT",
+                        "content": "ABCDEF",
+                        "ttl": "600",
+                        "prio": "0",
+                        "notes": ""
+                    }
+                ]
+            },
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "apikey": "key",
+                        "secretapikey": "secret"
+                    }
+                )
+            ]
+        )
+        responses.add_passthru("https://publicsuffix.org/list/public_suffix_list.dat")
+        responses.add_passthru(
+            "https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat"
+        )
+
+        namespace = Namespace(
+            porkbun_key="key",
+            porkbun_secret="secret",
+            porkbun_propagation_seconds=600,
+            config_dir="config_dir",
+            work_dir="work_dir",
+            logs_dir="logs_dir",
+            http01_port=80,
+            https_port=443,
+            domains=["example.com"],
+        )
+        config = NamespaceConfig(namespace)
+
+        authenticator = Authenticator(config, name="porkbun")
+
+        authenticator._perform(
+            domain="example.com", validation_name="", validation="ABCDEF"
+        )
+        assert responses.assert_call_count("https://api.porkbun.com/api/json/v3/dns/retrieveByNameType/example.com/TXT/_acme-challenge", 1) is True
+        assert responses.assert_call_count("https://api.porkbun.com/api/json/v3/dns/create/example.com", 0) is True
+
+    @responses.activate
     def test_cleanup(self):
         responses.post(
             url="https://api.porkbun.com/api/json/v3/dns/delete/example.com/123456789",

--- a/tests/cert_client.py
+++ b/tests/cert_client.py
@@ -29,6 +29,21 @@ class TestCertClient(unittest.TestCase):
                 )
             ],
         )
+        responses.post(
+            url="https://api.porkbun.com/api/json/v3/dns/retrieveByNameType/example.com/TXT/_acme-challenge",
+            json={
+                "status": "SUCCESS",
+                "records": []
+            },
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "apikey": "key",
+                        "secretapikey": "secret"
+                    }
+                )
+            ]
+        )
         responses.add_passthru("https://publicsuffix.org/list/public_suffix_list.dat")
         responses.add_passthru(
             "https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat"
@@ -52,25 +67,22 @@ class TestCertClient(unittest.TestCase):
         authenticator._perform(
             domain="example.com", validation_name="", validation="ABCDEF"
         )
+        assert responses.assert_call_count("https://api.porkbun.com/api/json/v3/dns/retrieveByNameType/example.com/TXT/_acme-challenge", 1) is True
+        assert responses.assert_call_count("https://api.porkbun.com/api/json/v3/dns/create/example.com", 1) is True
 
     @responses.activate
     def test_invalid_auth(self):
         responses.post(
-            url="https://api.porkbun.com/api/json/v3/dns/create/example.com",
+            url="https://api.porkbun.com/api/json/v3/dns/retrieveByNameType/example.com/TXT/_acme-challenge",
             json={"status": "ERROR", "message": "Invalid API key"},
             match=[
                 matchers.json_params_matcher(
                     {
                         "apikey": "key",
-                        "content": "ABCDEF",
-                        "name": "_acme-challenge",
-                        "prio": None,
-                        "secretapikey": "secret",
-                        "ttl": 300,
-                        "type": "TXT",
+                        "secretapikey": "wrong"
                     }
                 )
-            ],
+            ]
         )
         responses.add_passthru("https://publicsuffix.org/list/public_suffix_list.dat")
         responses.add_passthru(
@@ -116,6 +128,21 @@ class TestCertClient(unittest.TestCase):
                 )
             ],
         )
+        responses.post(
+            url="https://api.porkbun.com/api/json/v3/dns/retrieveByNameType/example.co.uk/TXT/_acme-challenge",
+            json={
+                "status": "SUCCESS",
+                "records": []
+            },
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "apikey": "key",
+                        "secretapikey": "secret"
+                    }
+                )
+            ]
+        )
         responses.add_passthru("https://publicsuffix.org/list/public_suffix_list.dat")
         responses.add_passthru(
             "https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat"
@@ -154,6 +181,21 @@ class TestCertClient(unittest.TestCase):
                 )
             ],
         )
+        responses.post(
+            url="https://api.porkbun.com/api/json/v3/dns/retrieveByNameType/example.com/TXT/_acme-challenge",
+            json={
+                "status": "SUCCESS",
+                "records": []
+            },
+            match=[
+                matchers.json_params_matcher(
+                    {
+                        "apikey": "key",
+                        "secretapikey": "secret"
+                    }
+                )
+            ]
+        )
         responses.add_passthru("https://publicsuffix.org/list/public_suffix_list.dat")
         responses.add_passthru(
             "https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat"
@@ -173,10 +215,6 @@ class TestCertClient(unittest.TestCase):
         config = NamespaceConfig(namespace)
 
         authenticator = Authenticator(config, name="porkbun")
-        authenticator._validation_to_record["ABCDEF"] = (
-            123456789,
-            "example.com",
-        )
 
         authenticator._cleanup(
             domain="example.com", validation_name="", validation="ABCDEF"


### PR DESCRIPTION
As of change #102, the DNS challenge will fail if there are **_any_** existing DNS challenge records. In my case specifically, I had several "stuck" DNS challenge records due to an edge case where I had not set the timeout high enough. This resulted in the certbot process hanging, and I had to kill the process manually to resolve the issue, presumably causing the challenge content to be regenerated once it restarted.

This change was manually tested with my personal domain.

I also noticed the unit tests were no longer working, so I fixed those as well.